### PR TITLE
fix(zshrc): migrate atuin to mise and remove dead curl install source

### DIFF
--- a/dots/.zshrc
+++ b/dots/.zshrc
@@ -232,3 +232,5 @@ eval "$(starship init zsh)"
 # Suppress Node.js deprecation warnings (e.g. punycode)
 export NODE_OPTIONS="--no-deprecation"
 export CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+eval "$(atuin init zsh)"

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -53,6 +53,7 @@ rclone = "latest"
 "aqua:simeji/jid" = "latest"
 "aqua:GoogleCloudPlatform/berglas" = "latest"
 rust = "latest"
+atuin = "latest"
 
 [settings]
 


### PR DESCRIPTION
Removed broken `. $HOME/.atuin/bin/env` sourced from the curl installer which was preventing `atuin init zsh` from running, breaking Ctrl+R. Uninstalled brew/curl copies and reinstalled via mise.