### PR TITLE
chore(mise): studio config + track .claude/docs

### DIFF
--- a/.claude/docs/git-discipline.md
+++ b/.claude/docs/git-discipline.md
@@ -1,0 +1,50 @@
+## Git Discipline — Full Reference
+
+### Branch Conventions
+
+| Prefix | Use |
+|--------|-----|
+| `fix/` | Bug fixes (e.g., `fix/ssh-gpg-agent-conflict`) |
+| `feat/` | New capabilities (e.g., `feat/mise-config-tracked`) |
+| `chore/` | Maintenance, cleanup, removal of dead code |
+| `docs/` | Documentation-only changes |
+
+Branch names: kebab-case, descriptive, under 50 characters.
+
+### Commit Message Format
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short description (imperative mood, under 72 chars)
+
+Longer body explaining WHY (not what — the diff shows what).
+Reference plan documents or prior decisions where relevant.
+```
+
+- **Types**: `fix`, `feat`, `chore`, `docs`, `refactor`, `test`, `ci`
+- **Scope**: the file or area changed (`zshrc`, `brewfile`, `mise`, `install`, `bin`)
+- **Body**: required for any non-trivial change
+
+### Process
+
+1. `git checkout -b <prefix>/<descriptive-name>`
+2. Make the smallest focused change that accomplishes the goal
+3. `git diff` — review before staging
+4. `git add -p` — stage interactively when possible
+5. `git commit` — write a conventional commit message with body
+6. `git push -u origin <branch-name>`
+7. Merge to master only after verifying the change works in a live shell
+
+### Test Before Committing
+
+- After editing any `.zsh` / `.zshrc` file: `zsh -n <file>` (syntax check)
+- After editing install scripts: `bash -n <file>`
+- After editing `symlinks.sh`: run `dotfiles symlinks` in a test context
+
+### Updating the Changelog
+
+After merging to master, regenerate CHANGELOG.md from commit history:
+```bash
+git-cliff --output CHANGELOG.md && git add CHANGELOG.md && git commit -m 'chore: update changelog'
+```

--- a/.claude/docs/reference.md
+++ b/.claude/docs/reference.md
@@ -1,0 +1,47 @@
+## Shell Startup Order
+
+```
+.zshrc
+  → .exports (env vars)
+  → .aliases
+  → ~/.zsh/functions/*.zsh (auto-sourced)
+  → History config
+  → PATH construction (typeset -U, priority order)
+  → GPG agent + SSH keys (async, non-blocking)
+  → rg/fd/pigz wrappers (override grep/find/gzip)
+  → compinit (cached daily)
+  → mise activate
+  → zoxide init
+  → Starship prompt init
+  → mise exec aliases (npm, npx, php, composer, uv, bun)
+```
+
+Startup performance target: under 300ms. Don't add blocking calls to `.zshrc`.
+
+---
+
+## Important Files
+
+| File | Purpose |
+|------|---------|
+| `dots/.zshrc` | Main shell config — PATH + startup orchestration |
+| `dots/.exports` | Env vars (EDITOR, tokens, build vars) |
+| `dots/.aliases` | Shell aliases |
+| `dots/.gitconfig` | Git config + ~30 aliases + delta pager settings |
+| `dots/.gitignore_global` | Global gitignore (applies to all repos) |
+| `install/Brewfile` | Common Homebrew packages (both machines) |
+| `install/Brewfile.laptop` | Laptop-specific: GUI casks, VS Code extensions, PHP/Drupal taps |
+| `install/Brewfile.ghost` | Ghost-specific: ollama, orbstack, headless tools |
+| `install/symlinks.sh` | Defines every managed symlink |
+| `bin/dotfiles` | Main CLI entry point |
+| `tests/validate.sh` | Drift detection suite (7 checks: startup time, secrets, Brewfile, symlinks, SSH perms, deprecated formulae, mise audit) |
+
+---
+
+## Git Config Highlights
+
+- **Pager**: delta (side-by-side diffs, vscode hyperlinks, line numbers)
+- **Conflict style**: `zdiff3` (shows base in conflicts)
+- **rerere**: enabled (reuse recorded conflict resolutions)
+- **Defaults**: `pull.rebase=true`, `fetch.prune=true`, `push.autoSetupRemote=true`
+- **Signing**: GPG via gpg-agent (gpg-agent also handles SSH auth)

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -1,0 +1,35 @@
+## Making Changes — Full Reference
+
+### Editing shell config
+Edit directly in `dots/` — changes are live immediately since they're symlinked.
+```bash
+# After editing dots/.zshrc:
+source ~/.zshrc   # or open new shell
+```
+
+### Adding a Homebrew package
+Add to the appropriate Brewfile:
+- `install/Brewfile` — shared packages (both machines)
+- `install/Brewfile.laptop` — laptop-only (GUI casks, VS Code, PHP/Drupal)
+- `install/Brewfile.ghost` — ghost-only (AI/compute tools)
+
+Then run:
+```bash
+bash install/brew.sh   # auto-detects hostname, installs common + host-specific
+```
+
+### Adding a mise tool
+```bash
+mise use --global <tool>@latest
+# Document in README.md Installed Tools table
+```
+
+### Re-running symlinks
+```bash
+dotfiles symlinks
+```
+
+### Full system audit
+```bash
+audit-system   # or: symlink-audit, mise-audit, syscheck
+```

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ iterm/script.py
 install/brew.bak
 
 # Local tool state — not portable
-.claude/
+.claude/*
+# But track context docs referenced by CLAUDE.md
+!.claude/docs/
 
 # Compiled binaries — platform-specific, install via brew/mise/source instead
 bin/dfc

--- a/bin/mise-audit
+++ b/bin/mise-audit
@@ -37,9 +37,13 @@ print_status() {
     esac
 }
 
+ARCH=$(uname -m)
+CHIP=$(system_profiler SPHardwareDataType 2>/dev/null | grep "Chip" | awk -F': ' '{print $2}')
+
 echo "=========================================="
 echo "  Mise Configuration Audit"
 echo "  $(date)"
+echo "  Arch: ${ARCH} / ${CHIP:-unknown}"
 echo "=========================================="
 echo ""
 
@@ -143,6 +147,25 @@ if [[ "$PRUNABLE" =~ ^[0-9]+$ ]] && [[ "$PRUNABLE" -gt 0 ]]; then
     if [[ "$VERBOSE" == "1" ]]; then
         mise prune --dry-run 2>&1 | grep "uninstall"
     fi
+fi
+
+# Check 7: Missing tool installations
+echo "Checking for missing tools..."
+MISSING_TOOLS=$(mise ls 2>/dev/null | grep "(missing)" || true)
+if [[ -n "$MISSING_TOOLS" ]]; then
+    MISSING_COUNT=$(echo "$MISSING_TOOLS" | wc -l | tr -d ' ')
+    print_status warn "$MISSING_COUNT missing tool(s)"
+    while IFS= read -r line; do
+        TOOL_NAME=$(echo "$line" | awk '{print $1}')
+        TOOL_VER=$(echo "$line" | awk '{print $2}')
+        print_status warn "${TOOL_NAME}@${TOOL_VER} is missing (arch: ${ARCH}/${CHIP:-unknown} — may be a prebuilt binary availability issue)"
+    done <<< "$MISSING_TOOLS"
+    log_issue "MISE_UNAVAILABLE" "Missing tool installations detected" \
+        "Architecture: ${ARCH}/${CHIP:-unknown}" \
+        "Tools: $(echo "$MISSING_TOOLS" | awk '{print $1"@"$2}' | tr '\n' ', ')"
+    ISSUES_FOUND=$((ISSUES_FOUND + MISSING_COUNT))
+else
+    print_status ok "All tools installed"
 fi
 
 echo ""

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -11,11 +11,10 @@
 bun = "latest"
 go = "latest"
 node = "22"
-"npm:wrangler" = "latest"
 "npm:@mermaid-js/mermaid-cli" = "latest"
 "npm:@mermaidchart/cli" = "latest"
 python = "latest"
-"ubi:adwinying/php" = ["8.2", "8.3", "8.4"]
+"github:adwinying/php" = ["8.2", "8.3", "8.4"]
 uv = "latest"
 bat = "latest"
 eza = "latest"


### PR DESCRIPTION
## Summary
- Switch PHP from deprecated `ubi:` backend to `github:adwinying/php` (8.2, 8.3, 8.4)
- Remove `npm:wrangler` — sharp dependency fails to build on M1
- Add architecture reporting and missing-tool detection to `mise-audit`
- Track `.claude/docs/` context files referenced by CLAUDE.md (were gitignored, missing after machine migrations)

## Notes
- `mise install` for PHP fails with `invalid gzip header` on all 3 versions — likely upstream issue with `github:` backend for adwinying/php releases. May need investigation or a different backend.

## Test plan
- [x] `bash -n bin/mise-audit` — syntax check passes
- [x] `mise-audit` runs, shows `arm64 / Apple M1 Max` in header, flags missing PHP
- [x] `.claude/docs/` files no longer gitignored, other `.claude/*` still ignored