### PR TITLE
feat(symlinks): add guarded ~/bin link for claude-sync

### DIFF
--- a/install/symlinks.sh
+++ b/install/symlinks.sh
@@ -67,3 +67,9 @@ for script in \
 do
     ln -sfv "$DOTFILES_DIR/bin/$script" ~/bin
 done
+
+# ---------------------------------------------------------------------------
+# External tools → ~/bin/ (guarded; only linked if the target exists)
+# ---------------------------------------------------------------------------
+[[ -x "$HOME/projects/dev-tools/claude-sync/claude-sync" ]] && \
+    ln -sfn "$HOME/projects/dev-tools/claude-sync/claude-sync" "$HOME/bin/claude-sync"


### PR DESCRIPTION
Links ~/projects/dev-tools/claude-sync/claude-sync into ~/bin so the tool is on PATH alongside the other bin entries, without vendoring its source into dotfiles. Guarded with -x so machines without the repo checked out don't end up with a dangling symlink.